### PR TITLE
perf: phase0 add-to-canvas optimizations

### DIFF
--- a/frontend/src/components/CanvasEditorRefactored.tsx
+++ b/frontend/src/components/CanvasEditorRefactored.tsx
@@ -36,10 +36,10 @@ rendererRegistry.register('pathFollower', PathFollowerRenderer);
 // PHASE0: accept refs so stage and layers are shared with consumers
 const CanvasProvider: React.FC<{
   children: React.ReactNode;
-  stageRef: React.RefObject<Konva.Stage>;
-  staticLayerRef: React.RefObject<Konva.Layer>;
-  animatedLayerRef: React.RefObject<Konva.Layer>;
-  overlayRootRef: React.RefObject<HTMLDivElement>;
+  stageRef: React.RefObject<Konva.Stage | null>;
+  staticLayerRef: React.RefObject<Konva.Layer | null>;
+  animatedLayerRef: React.RefObject<Konva.Layer | null>;
+  overlayRootRef: React.RefObject<HTMLDivElement | null>;
 }> = ({ children, stageRef, staticLayerRef, animatedLayerRef, overlayRootRef }) => {
   const contextValue = React.useMemo(() => ({
     stage: stageRef.current,
@@ -49,7 +49,7 @@ const CanvasProvider: React.FC<{
     clock: animationEngine,
     staticLayerRef,
     animatedLayerRef,
-  }), [stageRef, animatedLayerRef, overlayRootRef, staticLayerRef]);
+  }), [stageRef.current, staticLayerRef.current, animatedLayerRef.current, overlayRootRef.current]);
 
   return (
     <CanvasContext.Provider value={contextValue}>

--- a/frontend/src/components/SvgImporter.tsx
+++ b/frontend/src/components/SvgImporter.tsx
@@ -6,13 +6,90 @@ import SvgDrawSettings, { SvgDrawOptions, defaultSvgDrawOptions } from './SvgDra
 import { getPath2D } from '../utils/pathCache';
 import { measureSvgLengthsInWorker } from '../workers/measureWorkerClient';
 import { MeasureItem } from '../workers/measureTypes';
+// PHASE0: expose canvas context for layer-local redraws
+import { useCanvasContext } from './canvas';
 
-type ParsedPath = { d: string; stroke?: string; strokeWidth?: number; fill?: string; fillRule?: 'nonzero'|'evenodd' };
+// PHASE0: include optional perf-related fields on ParsedPath
+export type ParsedPath = {
+  d: string;
+  stroke?: string;
+  strokeWidth?: number;
+  fill?: string;
+  fillRule?: 'nonzero' | 'evenodd';
+  transform?: [number, number, number, number, number, number];
+  // Optional precomputed samples/lengths from importer
+  samples?: { x: number; y: number; cumulativeLength: number }[] | Float32Array;
+  len?: number;
+  // Optional lookup table for hand follower
+  lut?: { len: number; points: { s: number; x: number; y: number; theta: number }[] };
+};
+
+// PHASE0: feature flags (safe defaults)
+export const addToCanvas = { batched: true, batchSize: 50 } as const;
+export const lengths = { measureIncrementally: true, chunk: 64 } as const;
+export const importer = { dropTinyPaths: { enabled: true, minLenPx: 1.0 } } as const;
+export const debug = { perf: false } as const;
+
+// PHASE0: cooperative batched creator to keep UI responsive
+export async function createCanvasObjectBatched(
+  paths: ParsedPath[],
+  opts: { batchSize: number; onProgress?: (nDone: number, total: number) => void }
+): Promise<ParsedPath[]> {
+  const total = paths.length;
+  const result: ParsedPath[] = [];
+  for (let i = 0; i < total; i += opts.batchSize) {
+    const slice = paths.slice(i, i + opts.batchSize);
+    result.push(...slice);
+    opts.onProgress?.(Math.min(i + slice.length, total), total);
+    // Yield to main thread
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise(requestAnimationFrame);
+  }
+  return result;
+}
+
+// PHASE0: measure lengths for paths missing len in rAF chunks
+export async function measureMissingLengthsIncrementally(
+  paths: ParsedPath[],
+  chunk = 64,
+  onProgress?: (done: number, total: number) => void
+): Promise<number> {
+  const svgNS = 'http://www.w3.org/2000/svg';
+  const scratch = document.createElementNS(svgNS, 'path');
+  const missing = paths.filter(p => !(p as any).len && p.d);
+  const total = missing.length;
+  for (let i = 0; i < total; i += chunk) {
+    const end = Math.min(i + chunk, total);
+    for (let j = i; j < end; j++) {
+      const p = missing[j];
+      scratch.setAttribute('d', p.d);
+      (p as any).len = scratch.getTotalLength();
+    }
+    onProgress?.(end, total);
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise(requestAnimationFrame);
+  }
+  return total;
+}
+
+// PHASE0: helper for tiny-path filtering (exported for tests)
+export function dropTinyPaths(paths: ParsedPath[], minLenPx: number) {
+  const kept: ParsedPath[] = [];
+  let tinyCount = 0;
+  for (const p of paths) {
+    const L = (p as any).len ?? null;
+    if (L != null && L < minLenPx) {
+      tinyCount++;
+      continue;
+    }
+    kept.push(p);
+  }
+  return { kept, tinyDropped: tinyCount, total: paths.length };
+}
 
 // Hard caps to keep Add-to-Canvas responsive for extremely large SVGs
 const HARD_MAX_KEEP = 400; // absolute max number of paths in a single add
 const HARD_MAX_TOTAL_LEN = 1_500_000; // absolute cap on cumulative path length
-const PATHOBJ_BATCH = 500; // batch size when building path objects
 
 // Lightweight item used in Path Refinement UI
 // type RefineItem = {
@@ -27,6 +104,8 @@ const PATHOBJ_BATCH = 500; // batch size when building path objects
 const SvgImporter: React.FC = () => {
   const addObject = useAppStore(s => s.addObject);
   const currentProject = useAppStore(s => s.currentProject);
+  // PHASE0: layer reference for incremental drawing updates
+  const { animatedLayerRef } = useCanvasContext();
 
   const [status, setStatus] = React.useState<string>('');
   const [traceThreshold, setTraceThreshold] = React.useState<number>(128);
@@ -612,24 +691,54 @@ const SvgImporter: React.FC = () => {
       console.debug({ rawCount: combined.length, filteredCount: filtered.length, addedCount: capped.length, totalLenRounded: Math.round(totalLen) });
     }
 
-    const pathObjs: { d: string; stroke: string; strokeWidth: number; fill: string; transform?: number[]; len: number }[] = [];
-    for (let i = 0; i < capped.length; i += PATHOBJ_BATCH) {
-      const slice = capped.slice(i, i + PATHOBJ_BATCH);
-      for (let j = 0; j < slice.length; j++) {
-        const p = slice[j];
-        pathObjs.push({
-          d: p.d,
-          stroke: p.stroke || 'transparent',
-          strokeWidth: p.strokeWidth || 2,
-          fill: p.fill || 'transparent',
-          // TODO: remove legacy m fallback on next cleanup pass
-          transform: (p as any).transform ?? (p as any).m,
-          len: p.len,
-        });
+    // PHASE0: tiny-path early skip
+    let tinyMeta = { tinyDropped: 0, kept: capped.length, total: capped.length };
+    if (importer.dropTinyPaths.enabled) {
+      const res = dropTinyPaths(capped as ParsedPath[], importer.dropTinyPaths.minLenPx);
+      tinyMeta = { tinyDropped: res.tinyDropped, kept: res.kept.length, total: res.total };
+      capped = res.kept;
+      totalLen = Math.max(1, capped.reduce((s, p) => s + (p.len || 0), 0));
+    }
+
+    // PHASE0: build path objects in batches to keep UI responsive
+    let maxBatchMs = 0;
+    const addStart = performance.now();
+    let last = addStart;
+    const pathObjs = addToCanvas.batched
+      ? await createCanvasObjectBatched(capped as ParsedPath[], {
+          batchSize: addToCanvas.batchSize,
+          onProgress: () => {
+            const now = performance.now();
+            maxBatchMs = Math.max(maxBatchMs, now - last);
+            last = now;
+            animatedLayerRef?.current?.batchDraw();
+          },
+        })
+      : [...capped];
+    const addMs = performance.now() - addStart;
+    if (unmountedRef.current) return;
+
+    // PHASE0: record which perf fields were provided
+    const perfMarker = {
+      provided: {
+        samples: pathObjs.some(p => !!p.samples),
+        len: pathObjs.some(p => typeof p.len === 'number'),
+        lut: pathObjs.some(p => !!p.lut),
+      },
+    } as const;
+
+    // PHASE0: measure any missing lengths incrementally
+    let missingCount = 0;
+    let measureMs = 0;
+    if (lengths.measureIncrementally) {
+      const t0 = performance.now();
+      missingCount = await measureMissingLengthsIncrementally(pathObjs, lengths.chunk, () => {
+        animatedLayerRef?.current?.batchDraw();
+      });
+      measureMs = performance.now() - t0;
+      if (missingCount > 0) {
+        totalLen = Math.max(1, pathObjs.reduce((s, p) => s + (p.len || 0), 0));
       }
-      // eslint-disable-next-line no-await-in-loop
-      await new Promise(requestAnimationFrame);
-      if (unmountedRef.current) return;
     }
 
     const durationSec = finalOpts.speed.kind === 'duration'
@@ -649,12 +758,16 @@ const SvgImporter: React.FC = () => {
         totalLen,
         previewDraw: finalOpts.mode === 'preview',
         drawOptions: finalOpts,
+        // PHASE0: pass importer perf marker
+        __perf: perfMarker,
       },
       animationType: 'drawIn',
       animationStart: 0,
       animationDuration: durationSec,
       animationEasing: 'linear',
     });
+    // PHASE0: only redraw animated layer
+    animatedLayerRef?.current?.batchDraw();
     setStatus(
       finalOpts.mode === 'preview'
         ? '✅ Preview-style draw added to canvas'
@@ -662,6 +775,18 @@ const SvgImporter: React.FC = () => {
           ? '✅ Batched draw added to canvas'
           : '✅ Draw added to canvas',
     );
+
+    if (debug.perf) {
+      // eslint-disable-next-line no-console
+      console.log('[SvgImporter] perf', {
+        pathsTotal: tinyMeta.total,
+        pathsKept: tinyMeta.kept,
+        tinyDropped: tinyMeta.tinyDropped,
+        provided: perfMarker.provided,
+        add: { ms: Math.round(addMs), maxBatch: Math.round(maxBatchMs) },
+        incrementalLengths: { totalMissing: missingCount, ms: Math.round(measureMs) },
+      });
+    }
   }, [addObject, buildCanvasAnimFromSvg, currentProject, drawSvgSnapshot, drawOptions, resizeCanvasToHolder, computeSnapshotKey]);
   // Normalized SVG string for responsive preview (compute viewBox if missing; avoid TS deps)
   // ResizeObserver to auto-resize canvas on container or window resize

--- a/frontend/src/components/__tests__/SvgImporterHelpers.test.ts
+++ b/frontend/src/components/__tests__/SvgImporterHelpers.test.ts
@@ -1,0 +1,23 @@
+import { createCanvasObjectBatched, dropTinyPaths } from '../SvgImporter';
+
+// Polyfill rAF for node environment
+beforeAll(() => {
+  (global as any).requestAnimationFrame = (cb: any) => setTimeout(() => cb(0), 0);
+});
+
+test('batched creation yields multiple rAF breaks', async () => {
+  const paths = Array.from({ length: 120 }, (_, i) => ({ d: `M0 0 L${i} 0`, len: i }));
+  let calls = 0;
+  await createCanvasObjectBatched(paths as any, { batchSize: 50, onProgress: () => { calls++; } });
+  expect(calls).toBeGreaterThan(1);
+});
+
+test('tiny paths filtered when below threshold', () => {
+  const paths = [
+    { d: 'M0 0 L0 0', len: 0.5 },
+    { d: 'M0 0 L10 0', len: 10 }
+  ] as any;
+  const res = dropTinyPaths(paths, 1.0);
+  expect(res.kept.length).toBe(1);
+  expect(res.tinyDropped).toBe(1);
+});

--- a/frontend/src/components/canvas/CanvasContext.tsx
+++ b/frontend/src/components/canvas/CanvasContext.tsx
@@ -13,8 +13,8 @@ export interface CanvasContextType {
     stop: () => void;
   };
   // PHASE0: refs for static and animated layers
-  staticLayerRef?: React.RefObject<Konva.Layer>;
-  animatedLayerRef?: React.RefObject<Konva.Layer>;
+  staticLayerRef?: React.RefObject<Konva.Layer | null>;
+  animatedLayerRef?: React.RefObject<Konva.Layer | null>;
 }
 
 export const CanvasContext = React.createContext<CanvasContextType | null>(null);
@@ -26,3 +26,6 @@ export const useCanvasContext = (): CanvasContextType => {
   }
   return context;
 };
+
+// PHASE0: optional hook that returns null outside provider
+export const useCanvasContextOptional = (): CanvasContextType | null => React.useContext(CanvasContext);

--- a/frontend/src/components/canvas/CanvasContext.tsx
+++ b/frontend/src/components/canvas/CanvasContext.tsx
@@ -12,6 +12,9 @@ export interface CanvasContextType {
     start: () => void;
     stop: () => void;
   };
+  // PHASE0: refs for static and animated layers
+  staticLayerRef?: React.RefObject<Konva.Layer>;
+  animatedLayerRef?: React.RefObject<Konva.Layer>;
 }
 
 export const CanvasContext = React.createContext<CanvasContextType | null>(null);

--- a/frontend/src/components/canvas/__tests__/SvgPathRendererPhase0.test.tsx
+++ b/frontend/src/components/canvas/__tests__/SvgPathRendererPhase0.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { SvgPathRenderer } from '../renderers/SvgPathRenderer';
+import { PathSampler } from '../../../utils/pathSampler';
+
+// Use shared Konva mocks that sanitize props
+jest.mock('react-konva', () => require('../../../testUtils/reactKonvaMock').default);
+
+test('uses provided samples and len when available', () => {
+  const samples = [
+    { x: 0, y: 0, cumulativeLength: 0 },
+    { x: 10, y: 0, cumulativeLength: 10 }
+  ];
+  const obj = {
+    id: 'v1',
+    type: 'svgPath',
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+    rotation: 0,
+    properties: { paths: [{ d: 'M0 0 L10 0', len: 10, samples }], totalLen: 10 },
+    animationStart: 0,
+    animationDuration: 1,
+    animationType: 'none',
+    animationEasing: 'linear'
+  } as any;
+
+  const spy = jest.spyOn(PathSampler, 'samplePath');
+  render(
+    <SvgPathRenderer
+      obj={obj}
+      animatedProps={{}}
+      currentTime={0}
+      isSelected={false}
+      tool="select"
+      onClick={() => {}}
+      onDragEnd={() => {}}
+      onDragMove={() => {}}
+      onTransformEnd={() => {}}
+    />
+  );
+  expect(spy).not.toHaveBeenCalled();
+});

--- a/frontend/src/components/canvas/index.ts
+++ b/frontend/src/components/canvas/index.ts
@@ -1,5 +1,5 @@
 // Canvas module exports
-export { CanvasContext, useCanvasContext } from './CanvasContext';
+export { CanvasContext, useCanvasContext, useCanvasContextOptional } from './CanvasContext';
 export { rendererRegistry } from './renderers/RendererRegistry';
 export { animationEngine, AnimationEngine } from './animation/AnimationEngine';
 export { useObjectController } from './controllers/useObjectController';

--- a/frontend/src/components/canvas/renderers/SvgPathRenderer.tsx
+++ b/frontend/src/components/canvas/renderers/SvgPathRenderer.tsx
@@ -5,6 +5,13 @@ import { calculateAnimationProgress } from '../utils/animationUtils';
 import ThreeLayerHandFollower from '../../hands/ThreeLayerHandFollower';
 import { PathSampler } from '../../../utils/pathSampler';
 import { getPath2D, getHandLUT, HandLUT } from '../../../utils/pathCache';
+import type { ParsedPath } from '../../../types/parsedPath';
+
+// PHASE0: internal extension with cached fields
+interface CachedParsedPath extends ParsedPath {
+  _samples?: any; // PathPoint[] | Float32Array
+  _lut?: HandLUT | null;
+}
 
 // Note: splitSubpaths no longer used in this renderer
 
@@ -83,31 +90,32 @@ export const SvgPathRenderer: React.FC<BaseRendererProps> = ({
       const drawablePathsTemp: any[] = [];
       let sum = 0;
       
-      arr.forEach((p: any, index: number) => {
+      arr.forEach((p: ParsedPath, index: number) => {
         const d = p?.d as string | undefined;
         if (!d) return;
 
+        const cp = p as CachedParsedPath;
         // PHASE0: reuse provided samples/lengths when available
-        if (p.samples && !(p as any)._samples) (p as any)._samples = p.samples;
-        if (p.lut && !(p as any)._lut) (p as any)._lut = p.lut;
+        if (p.samples && !cp._samples) cp._samples = p.samples;
+        if (p.lut && !cp._lut) cp._lut = p.lut;
+        if (!cp._samples) {
+          try {
+            cp._samples = PathSampler.samplePath(d, 1.25, undefined);
+          } catch (error) {
+            cp._samples = [];
+          }
+        }
         let len = typeof p.len === 'number' ? p.len : 0;
         if (len <= 0) {
-          if (!(p as any)._samples) {
-            try {
-              (p as any)._samples = PathSampler.samplePath(d, 1.25, undefined);
-            } catch (error) {
-              (p as any)._samples = [];
-            }
-          }
-          const _s = (p as any)._samples as ReturnType<typeof PathSampler.samplePath>;
+          const _s = cp._samples;
           len = _s && _s.length ? _s[_s.length - 1].cumulativeLength : 0;
         }
-        (p as any).len = len;
-        if (!(p as any)._lut) {
+        cp.len = len;
+        if (!cp._lut) {
           try {
-            (p as any)._lut = getHandLUT(d, 2);
+            cp._lut = getHandLUT(d, 2);
           } catch {
-            (p as any)._lut = null;
+            cp._lut = null;
           }
         }
 
@@ -127,9 +135,9 @@ export const SvgPathRenderer: React.FC<BaseRendererProps> = ({
     const drawablePathsTemp: any[] = [];
     let sum = 0;
     
-    arr.forEach((p: any, index: number) => {
-      const d = p?.d as string | undefined;
-      if (!d) {
+      arr.forEach((p: ParsedPath, index: number) => {
+        const d = p?.d as string | undefined;
+        if (!d) {
         if (debug) {
           console.warn('[SvgPathRenderer] Path missing d attribute:', p);
         }
@@ -143,28 +151,29 @@ export const SvgPathRenderer: React.FC<BaseRendererProps> = ({
       }
 
       // PHASE0: reuse provided sampler results
-      if (p.samples && !(p as any)._samples) (p as any)._samples = p.samples;
-      if (p.lut && !(p as any)._lut) (p as any)._lut = p.lut;
+      const cp = p as CachedParsedPath;
+      if (p.samples && !cp._samples) cp._samples = p.samples;
+      if (p.lut && !cp._lut) cp._lut = p.lut;
+      if (!cp._samples) {
+        try {
+          cp._samples = PathSampler.samplePath(d, 1.25, undefined);
+        } catch (error) {
+          debugLog('error', '[SvgPathRenderer] PathSampler failed for path:', d, error);
+          cp._samples = [];
+        }
+      }
       let len = typeof p.len === 'number' ? p.len : 0;
       if (len <= 0) {
-        if (!(p as any)._samples) {
-          try {
-            (p as any)._samples = PathSampler.samplePath(d, 1.25, undefined);
-          } catch (error) {
-            debugLog('error', '[SvgPathRenderer] PathSampler failed for path:', d, error);
-            (p as any)._samples = [];
-          }
-        }
         // Use cached samples to compute transform-aware length
-        const _s = (p as any)._samples as ReturnType<typeof PathSampler.samplePath>;
+        const _s = cp._samples;
         len = _s && _s.length ? _s[_s.length - 1].cumulativeLength : 0;
       }
-      (p as any).len = len;
-      if (!(p as any)._lut) {
+      cp.len = len;
+      if (!cp._lut) {
         try {
-          (p as any)._lut = getHandLUT(d, 2);
+          cp._lut = getHandLUT(d, 2);
         } catch {
-          (p as any)._lut = null;
+          cp._lut = null;
         }
       }
 
@@ -172,7 +181,7 @@ export const SvgPathRenderer: React.FC<BaseRendererProps> = ({
         drawablePathsTemp.push({ ...p, index, len });
         sum += len;
       } else if (debug) {
-        const debugSamples = (p as any)._samples as ReturnType<typeof PathSampler.samplePath> | undefined;
+        const debugSamples = cp._samples;
         console.warn('[SvgPathRenderer] Path has zero length:', { d, samples: debugSamples?.length ?? 0, index });
       }
     });

--- a/frontend/src/types/parsedPath.ts
+++ b/frontend/src/types/parsedPath.ts
@@ -1,0 +1,14 @@
+// PHASE0: shared ParsedPath type with optional perf fields
+export interface ParsedPath {
+  d: string;
+  stroke?: string;
+  strokeWidth?: number;
+  fill?: string;
+  fillRule?: 'nonzero' | 'evenodd';
+  transform?: [number, number, number, number, number, number];
+  // Optional precomputed samples/lengths from importer
+  samples?: { x: number; y: number; cumulativeLength: number }[] | Float32Array;
+  len?: number;
+  // Optional lookup table for hand follower
+  lut?: { len: number; points: { s: number; x: number; y: number; theta: number }[] };
+}


### PR DESCRIPTION
## Summary
- cache importer samples/lengths and reuse in SvgPathRenderer
- batch "Add to Canvas" work and draw only the animated layer
- measure missing path lengths incrementally and drop tiny paths with optional telemetry

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'canvas' / import.meta parse)*

------
https://chatgpt.com/codex/tasks/task_e_68b983c1a2708325a3b3a9c39ceb5840